### PR TITLE
Ensure Multipart content-type is cleared

### DIFF
--- a/lib/ketting.js
+++ b/lib/ketting.js
@@ -164,7 +164,12 @@ Ketting.prototype = {
       }
 
     }
-
+    
+    //if the header Content-Type is set to multipart - ensure it is cleared so fetch can set correct headers automatically.
+    if (request.headers.get("Content-Type") === "multipart/form-data") {
+      request.headers.delete("Content-Type");
+    }
+    
     return fetch(request);
 
   },


### PR DESCRIPTION
This ensure the fetch api can set the content-type header automatically - this is needed when using form-data for uploading files, otherwise the header will not be set correctly and the upload will fail. 